### PR TITLE
Add user API integration with offline cache

### DIFF
--- a/integration_test/message_flow_test.dart
+++ b/integration_test/message_flow_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:chat_app_1/main.dart' as app;
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:chat_app_1/core/local/local_storage.dart';
+import 'package:chat_app_1/features/chat/data/models/chat_message.dart';
+import 'package:chat_app_1/features/chat/data/models/users_listing_model.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('send message saved locally', (tester) async {
+    await Hive.initFlutter();
+    Hive.registerAdapter(ChatMessageAdapter());
+    Hive.registerAdapter(UsersListingModelAdapter());
+    Hive.registerAdapter(UserAdapter());
+    await Hive.openBox<ChatMessage>(HiveServiceImpl.chatBoxName);
+    await Hive.openBox<User>(HiveServiceImpl.userBoxName);
+
+    app.main();
+    await tester.pumpAndSettle();
+
+    // open first chat (using first user name)
+    await tester.tap(find.text('Jane').first, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    final box = Hive.box<ChatMessage>(HiveServiceImpl.chatBoxName);
+    final exists = box.values.any((m) => m.message == 'hello');
+    expect(exists, true);
+  });
+}

--- a/lib/features/chat/data/datasources/number_trivia_remote_data_source.dart
+++ b/lib/features/chat/data/datasources/number_trivia_remote_data_source.dart
@@ -18,11 +18,10 @@ class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
   ChatRemoteDataSourceImpl({required this.client});
 
   @override
-  Future<UsersListingModel> getAllUsers() => _getTriviaFromUrl(
-    'https://mocki.io/v1/6ecdc9fe-01f5-4f6a-83a8-38e8419103be',
-  );
+  Future<UsersListingModel> getAllUsers() =>
+      _getUsersFromUrl('https://mocki.io/v1/e91cbee6-6087-455a-9d88-8c5b28805404');
 
-  Future<UsersListingModel> _getTriviaFromUrl(String url) async {
+  Future<UsersListingModel> _getUsersFromUrl(String url) async {
     final response = await client.get(
       Uri.parse(url),
       headers: {'Content-Type': 'application/json'},

--- a/lib/features/chat/data/models/users_listing_model.dart
+++ b/lib/features/chat/data/models/users_listing_model.dart
@@ -9,12 +9,25 @@ part 'users_listing_model.g.dart';
 class UsersListingModel extends Equatable {
   const UsersListingModel({required this.users});
   @HiveField(0)
-  final List<User>? users;
+  final List<User> users;
 
-  factory UsersListingModel.fromJson(Map<String, dynamic> json) =>
-      _$UsersListingModelFromJson(json);
+  factory UsersListingModel.fromJson(dynamic json) {
+    if (json is List) {
+      return UsersListingModel(
+          users: json
+              .map((e) => User.fromJson(e as Map<String, dynamic>))
+              .toList());
+    } else if (json is Map<String, dynamic>) {
+      return UsersListingModel(
+          users: (json['users'] as List<dynamic>)
+              .map((e) => User.fromJson(e as Map<String, dynamic>))
+              .toList());
+    } else {
+      throw Exception('Invalid json');
+    }
+  }
 
-  Map<String, dynamic> toJson() => _$UsersListingModelToJson(this);
+  Map<String, dynamic> toJson() => {'users': users};
 
   @override
   List<Object?> get props => [users];
@@ -25,22 +38,20 @@ class UsersListingModel extends Equatable {
 class User extends Equatable {
   const User({
     required this.name,
-    required this.profileImage,
+    required this.avatar,
     required this.id,
   });
   @HiveField(0)
-  final String? name;
+  final String name;
   @HiveField(1)
-  @JsonKey(name: 'profile_image')
-  final String? profileImage;
+  final String avatar;
   @HiveField(2)
-  @JsonKey(name: '_id')
-  final String id;
+  final int id;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
   Map<String, dynamic> toJson() => _$UserToJson(this);
 
   @override
-  List<Object?> get props => [name, profileImage];
+  List<Object?> get props => [name, avatar, id];
 }

--- a/lib/features/chat/data/models/users_listing_model.g.dart
+++ b/lib/features/chat/data/models/users_listing_model.g.dart
@@ -17,7 +17,7 @@ class UsersListingModelAdapter extends TypeAdapter<UsersListingModel> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return UsersListingModel(
-      users: (fields[0] as List?)?.cast<User>(),
+      users: (fields[0] as List).cast<User>(),
     );
   }
 
@@ -51,9 +51,9 @@ class UserAdapter extends TypeAdapter<User> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return User(
-      name: fields[0] as String?,
-      profileImage: fields[1] as String?,
-      id: fields[2] as String,
+      name: fields[0] as String,
+      avatar: fields[1] as String,
+      id: fields[2] as int,
     );
   }
 
@@ -64,7 +64,7 @@ class UserAdapter extends TypeAdapter<User> {
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
-      ..write(obj.profileImage)
+      ..write(obj.avatar)
       ..writeByte(2)
       ..write(obj.id);
   }
@@ -86,8 +86,8 @@ class UserAdapter extends TypeAdapter<User> {
 
 UsersListingModel _$UsersListingModelFromJson(Map<String, dynamic> json) =>
     UsersListingModel(
-      users: (json['users'] as List<dynamic>?)
-          ?.map((e) => User.fromJson(e as Map<String, dynamic>))
+      users: (json['users'] as List<dynamic>)
+          .map((e) => User.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
@@ -97,13 +97,13 @@ Map<String, dynamic> _$UsersListingModelToJson(UsersListingModel instance) =>
     };
 
 User _$UserFromJson(Map<String, dynamic> json) => User(
-      name: json['name'] as String?,
-      profileImage: json['profile_image'] as String?,
-      id: json['_id'] as String,
+      name: json['name'] as String,
+      avatar: json['avatar'] as String,
+      id: json['id'] as int,
     );
 
 Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
       'name': instance.name,
-      'profile_image': instance.profileImage,
-      '_id': instance.id,
+      'avatar': instance.avatar,
+      'id': instance.id,
     };

--- a/lib/features/chat/data/repositories/user_repository_impl.dart
+++ b/lib/features/chat/data/repositories/user_repository_impl.dart
@@ -34,10 +34,17 @@ class UsersRepostoryImpl implements UserRepository {
     if (await networkInfo.isConnected) {
       try {
         final users = await getUsers();
-        localDataSource.getAllCachedUserProfile();
+        for (final user in users.users) {
+          await localDataSource.cacheUserProfile(user);
+        }
         return Right(users);
       } on ServerException {
-        return Left(ServerFailure());
+        try {
+          final users = await localDataSource.getAllCachedUserProfile();
+          return Right(UsersListingModel(users: users));
+        } on CacheException {
+          return Left(ServerFailure());
+        }
       }
     } else {
       try {

--- a/lib/features/chat/presentation/pages/chat_screen.dart
+++ b/lib/features/chat/presentation/pages/chat_screen.dart
@@ -1,6 +1,10 @@
-import 'package:chat_app_1/features/chat/data/models/users_listing_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../injection_container.dart';
+import '../../../core/network/network_info.dart';
+import '../../data/models/users_listing_model.dart';
+import '../bloc/bloc/fetch_all_users_bloc.dart';
 import '../widgets/chat_screen_widgets/chat_header.dart';
 import '../widgets/chat_screen_widgets/chat_list_items.widget.dart';
 import 'individual_chat_screen.dart';
@@ -16,8 +20,15 @@ class ChatScreenState extends State<ChatScreen> {
   bool isConnected = true;
   ChatItem? selectedChat;
 
-  ///TODO: fetch users from local or api
-  final UsersListingModel usersModel = UsersListingModel(users: []);
+  @override
+  void initState() {
+    super.initState();
+    locator<NetworkInfo>().isConnected.then((value) {
+      setState(() {
+        isConnected = value;
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,28 +45,41 @@ class ChatScreenState extends State<ChatScreen> {
 
                 // Chat List
                 Expanded(
-                  child: ListView.separated(
-                    itemCount: usersModel.users?.length ?? 0,
-                    separatorBuilder: (context, index) =>
-                        Divider(height: 1, color: Colors.grey.shade100),
-                    itemBuilder: (context, index) {
-                      final user = usersModel.users?[index];
-                      return ChatListItem(
-                        user: user,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) {
-                                return IndividualChatScreen(
-                                  contactName: user?.name ?? '',
-                                  contactAvatar: user?.profileImage ?? '',
+                  child: BlocBuilder<UserBloc, UserState>(
+                    builder: (context, state) {
+                      if (state is UserLoading) {
+                        return const Center(child: CircularProgressIndicator());
+                      } else if (state is UserLoaded) {
+                        final users = state.usersListing.users;
+                        return ListView.separated(
+                          itemCount: users.length,
+                          separatorBuilder: (context, index) =>
+                              Divider(height: 1, color: Colors.grey.shade100),
+                          itemBuilder: (context, index) {
+                            final user = users[index];
+                            return ChatListItem(
+                              user: user,
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) {
+                                      return IndividualChatScreen(
+                                        contactName: user.name,
+                                        contactAvatar: user.avatar,
+                                      );
+                                    },
+                                  ),
                                 );
                               },
-                            ),
-                          );
-                        },
-                      );
+                            );
+                          },
+                        );
+                      } else if (state is UserError) {
+                        return Center(child: Text(state.message));
+                      } else {
+                        return const SizedBox();
+                      }
                     },
                   ),
                 ),

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -1,7 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:http/http.dart' as http;
+import 'package:data_connection_checker_tv/data_connection_checker.dart';
 
 import 'core/local/local_storage.dart';
+import 'core/network/network_info.dart';
+import 'features/chat/data/datasources/chat_local_data_source.dart';
+import 'features/chat/data/datasources/number_trivia_remote_data_source.dart';
+import 'features/chat/data/models/chat_message.dart';
+import 'features/chat/data/models/users_listing_model.dart';
+import 'features/chat/data/repositories/user_repository_impl.dart';
+import 'features/chat/domain/repositories/user_repository.dart';
+import 'features/chat/domain/usecases/get_all_users_usecase.dart';
+import 'features/chat/presentation/bloc/bloc/fetch_all_users_bloc.dart';
 
 final locator = GetIt.instance;
 
@@ -13,4 +24,23 @@ Future<void> setupDependency() async {
   await localStorage.init();
 
   locator.registerSingleton<HiveService>(localStorage);
+
+  locator.registerLazySingleton(() => http.Client());
+  locator.registerLazySingleton(() => DataConnectionChecker());
+  locator.registerLazySingleton<NetworkInfo>(
+      () => NetworkInfoImpl(locator<DataConnectionChecker>()));
+
+  locator.registerLazySingleton<ChatLocalDataSource>(() => ChatLocalDataSourceImpl(
+        chatBox: Hive.box<ChatMessage>(HiveServiceImpl.chatBoxName),
+        userBox: Hive.box<User>(HiveServiceImpl.userBoxName),
+      ));
+  locator.registerLazySingleton<ChatRemoteDataSource>(
+      () => ChatRemoteDataSourceImpl(client: locator()));
+  locator.registerLazySingleton<UserRepository>(() => UsersRepostoryImpl(
+        remoteDataSource: locator(),
+        localDataSource: locator(),
+        networkInfo: locator(),
+      ));
+  locator.registerLazySingleton(() => GetAllUsers(locator()));
+  locator.registerFactory(() => UserBloc(getAllUsers: locator()));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'features/chat/presentation/pages/chat_screen.dart';
+import 'features/chat/presentation/bloc/bloc/fetch_all_users_bloc.dart';
 import 'injection_container.dart';
 
 void main() async {
@@ -17,7 +19,10 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Chat App',
-      home: ChatScreen(),
+      home: BlocProvider(
+        create: (_) => locator<UserBloc>()..add(const GetAllUsersEvent()),
+        child: const ChatScreen(),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  bloc_test: ^9.1.0
+  mocktail: ^1.0.3
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/chat_screen_test.dart
+++ b/test/chat_screen_test.dart
@@ -1,0 +1,49 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:chat_app_1/features/chat/data/models/users_listing_model.dart';
+import 'package:chat_app_1/features/chat/presentation/bloc/bloc/fetch_all_users_bloc.dart';
+import 'package:chat_app_1/features/chat/presentation/pages/chat_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
+
+class FakeUserEvent extends Fake implements UserEvent {}
+
+class FakeUserState extends Fake implements UserState {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeUserEvent());
+    registerFallbackValue(FakeUserState());
+  });
+
+  testWidgets('ChatScreen displays users list', (tester) async {
+    final mockBloc = MockUserBloc();
+    final users = UsersListingModel(users: [
+      const User(name: 'Jane', avatar: 'a.png', id: 1),
+      const User(name: 'John', avatar: 'b.png', id: 2),
+    ]);
+
+    whenListen(
+      mockBloc,
+      Stream<UserState>.fromIterable([UserLoaded(usersListing: users)]),
+      initialState: UserLoaded(usersListing: users),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider<UserBloc>.value(
+          value: mockBloc,
+          child: const ChatScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Jane'), findsOneWidget);
+    expect(find.text('John'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- connect to new users API and store users locally
- use Bloc architecture to load users in `ChatScreen`
- update repository to cache offline data
- wire up dependencies in `injection_container`
- persist chat messages to Hive and load them on startup
- add widget and integration tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885b0ef10d0832688b398f26fc7aaac