### PR TITLE
Integrate WebSocket messaging

### DIFF
--- a/integration_test/message_flow_test.dart
+++ b/integration_test/message_flow_test.dart
@@ -10,7 +10,7 @@ import 'package:chat_app_1/features/chat/data/models/users_listing_model.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('send message saved locally', (tester) async {
+  testWidgets('send and receive messages are saved locally', (tester) async {
     await Hive.initFlutter();
     Hive.registerAdapter(ChatMessageAdapter());
     Hive.registerAdapter(UsersListingModelAdapter());
@@ -28,9 +28,11 @@ void main() {
     await tester.enterText(find.byType(TextField), 'hello');
     await tester.tap(find.byIcon(Icons.send));
     await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
 
     final box = Hive.box<ChatMessage>(HiveServiceImpl.chatBoxName);
-    final exists = box.values.any((m) => m.message == 'hello');
-    expect(exists, true);
+    final sent = box.values.any((m) => m.message == 'hello' && m.senderId == 'user');
+    final received = box.values.any((m) => m.message == 'hello' && m.senderId == 'bot');
+    expect(sent && received, true);
   });
 }

--- a/lib/core/network/websocket_service.dart
+++ b/lib/core/network/websocket_service.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class WebSocketService {
+  final String url;
+  final WebSocketChannel Function(Uri url)? channelFactory;
+  WebSocketChannel? _channel;
+  final _messageController = StreamController<String>.broadcast();
+  final _connectionController = StreamController<bool>.broadcast();
+
+  Stream<String> get messages => _messageController.stream;
+  Stream<bool> get connectionStatus => _connectionController.stream;
+
+  WebSocketService({required this.url, this.channelFactory});
+
+  void connect() {
+    try {
+      final connect = channelFactory ??
+          ((uri) => WebSocketChannel.connect(uri));
+      _channel = connect(Uri.parse(url));
+      _connectionController.add(true);
+      _channel!.stream.listen((event) {
+        _messageController.add(event);
+      }, onError: (_) {
+        _connectionController.add(false);
+      }, onDone: () {
+        _connectionController.add(false);
+      });
+    } catch (e) {
+      _connectionController.add(false);
+    }
+  }
+
+  void send(String message) {
+    _channel?.sink.add(message);
+  }
+
+  void disconnect() {
+    _channel?.sink.close();
+    _connectionController.add(false);
+  }
+}

--- a/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_app_bar.dart
+++ b/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_app_bar.dart
@@ -5,11 +5,13 @@ import '../chat_screen_widgets/chat_avatar.dart';
 class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String contactName;
   final String contactAvatar;
+  final bool isConnected;
 
   const ChatAppBar({
     super.key,
     required this.contactName,
     required this.contactAvatar,
+    required this.isConnected,
   });
 
   @override
@@ -40,6 +42,16 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
           ),
         ],
       ),
+      actions: [
+        Padding(
+          padding: EdgeInsets.only(right: 12),
+          child: Icon(
+            Icons.circle,
+            color: isConnected ? Colors.green : Colors.red,
+            size: 12,
+          ),
+        )
+      ],
     );
   }
 

--- a/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_input_area.dart
+++ b/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_input_area.dart
@@ -4,11 +4,13 @@ import 'send_button.dart';
 class ChatInputArea extends StatelessWidget {
   final TextEditingController controller;
   final VoidCallback onSendMessage;
+  final ValueChanged<String>? onChanged;
 
   const ChatInputArea({
     Key? key,
     required this.controller,
     required this.onSendMessage,
+    this.onChanged,
   }) : super(key: key);
 
   @override
@@ -37,6 +39,7 @@ class ChatInputArea extends StatelessWidget {
                         hintStyle: TextStyle(color: Colors.grey[600]),
                         border: InputBorder.none,
                       ),
+                      onChanged: onChanged,
                       onSubmitted: (_) => onSendMessage(),
                     ),
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   bloc: ^9.0.0
   flutter_bloc: ^9.1.1
   cached_network_image: ^3.4.1
+  web_socket_channel: ^3.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/chat_screen_test.dart
+++ b/test/chat_screen_test.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:chat_app_1/core/network/network_info.dart';
+import 'package:chat_app_1/injection_container.dart';
 
 class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
 
@@ -13,8 +16,14 @@ class FakeUserEvent extends Fake implements UserEvent {}
 
 class FakeUserState extends Fake implements UserState {}
 
+class FakeNetworkInfo extends Fake implements NetworkInfo {
+  @override
+  Future<bool> get isConnected async => true;
+}
+
 void main() {
   setUpAll(() {
+    locator.registerSingleton<NetworkInfo>(FakeNetworkInfo());
     registerFallbackValue(FakeUserEvent());
     registerFallbackValue(FakeUserState());
   });

--- a/test/individual_chat_screen_test.dart
+++ b/test/individual_chat_screen_test.dart
@@ -1,0 +1,118 @@
+import 'package:chat_app_1/core/local/local_storage.dart';
+import 'package:chat_app_1/core/network/websocket_service.dart';
+import 'package:chat_app_1/features/chat/presentation/pages/individual_chat_screen.dart';
+import 'package:chat_app_1/features/chat/data/models/chat_message.dart';
+import 'package:chat_app_1/features/chat/data/models/users_listing_model.dart';
+import 'package:chat_app_1/injection_container.dart';
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+
+class FakeHiveService extends Fake implements HiveService {
+  final List<ChatMessage> stored = [];
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  List<ChatMessage> getAllMessages() => [];
+
+  @override
+  Future<void> saveMessage(ChatMessage message) async {
+    stored.add(message);
+  }
+
+  @override
+  Future<void> clearMessages() async {}
+
+  @override
+  Future<void> saveUser(User profile) async {}
+
+  @override
+  User? getUser(String userId) => null;
+
+  @override
+  Future<void> clearUsers() async {}
+}
+
+class FakeWebSocketService extends WebSocketService {
+  FakeWebSocketService() : super(url: 'ws://test');
+  final List<String> sent = [];
+  final StreamController<String> _controller = StreamController.broadcast();
+  final StreamController<bool> _status = StreamController<bool>.broadcast();
+
+  @override
+  Stream<String> get messages => _controller.stream;
+
+  @override
+  Stream<bool> get connectionStatus => _status.stream;
+
+  @override
+  void connect() {
+    _status.add(true);
+  }
+
+  @override
+  void send(String message) {
+    sent.add(message);
+  }
+
+  void emit(String msg) => _controller.add(msg);
+
+  @override
+  void disconnect() {
+    _status.add(false);
+  }
+}
+
+void main() {
+  final locator = GetIt.instance;
+
+  setUp(() {
+    if (!locator.isRegistered<HiveService>()) {
+      locator.registerSingleton<HiveService>(FakeHiveService());
+    }
+  });
+
+  testWidgets('shows connection indicator and sends message', (tester) async {
+    final ws = FakeWebSocketService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IndividualChatScreen(
+          contactName: 'Bot',
+          contactAvatar: 'a.png',
+          webSocketService: ws,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final icon = tester.widget<Icon>(find.byIcon(Icons.circle));
+    expect(icon.color, Colors.green);
+
+    await tester.enterText(find.byType(TextField), 'hi');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(ws.sent, contains('hi'));
+  });
+
+  testWidgets('shows typing indicator on incoming typing event', (tester) async {
+    final ws = FakeWebSocketService();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IndividualChatScreen(
+          contactName: 'Bot',
+          contactAvatar: 'a.png',
+          webSocketService: ws,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    ws.emit('__typing__');
+    await tester.pump();
+    expect(find.text('Bot is typing...'), findsOneWidget);
+  });
+}

--- a/test/websocket_service_test.dart
+++ b/test/websocket_service_test.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:chat_app_1/core/network/websocket_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+class MockWebSocketChannel extends Mock implements WebSocketChannel {}
+class MockWebSocketSink extends Mock implements WebSocketSink {}
+
+void main() {
+  late MockWebSocketChannel channel;
+  late MockWebSocketSink sink;
+
+  setUp(() {
+    channel = MockWebSocketChannel();
+    sink = MockWebSocketSink();
+    when(() => channel.sink).thenReturn(sink);
+    when(() => channel.stream).thenAnswer((_) => const Stream.empty());
+  });
+
+  test('send forwards message to sink', () {
+    final service = WebSocketService(url: 'ws://test', channelFactory: (_) => channel);
+    service.connect();
+
+    service.send('hello');
+
+    verify(() => sink.add('hello')).called(1);
+  });
+
+  test('messages are forwarded from stream', () async {
+    final controller = StreamController<String>();
+    when(() => channel.stream).thenAnswer((_) => controller.stream);
+    final service = WebSocketService(url: 'ws://test', channelFactory: (_) => channel);
+    final received = <String>[];
+    service.messages.listen(received.add);
+
+    service.connect();
+    controller.add('hi');
+    await Future.delayed(Duration.zero);
+
+    expect(received, ['hi']);
+  });
+}


### PR DESCRIPTION
## Summary
- add injection point for WebSocketChannel
- store received messages to Hive
- allow passing custom WebSocket service to chat screen
- add unit tests for WebSocket service
- add widget tests for chat screen UI
- extend integration test for send/receive flow

## Testing
- `flutter test` *(fails: ChatScreen widget test error)*

------
https://chatgpt.com/codex/tasks/task_e_6885c620cea883268eab48e698527554