### PR TITLE
Show websocket status in header

### DIFF
--- a/lib/core/network/websocket_service.dart
+++ b/lib/core/network/websocket_service.dart
@@ -1,33 +1,41 @@
 import 'dart:async';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+enum WsConnectionStatus { connecting, connected, disconnected }
+
 class WebSocketService {
   final String url;
   final WebSocketChannel Function(Uri url)? channelFactory;
   WebSocketChannel? _channel;
   final _messageController = StreamController<String>.broadcast();
-  final _connectionController = StreamController<bool>.broadcast();
+  final _connectionController =
+      StreamController<WsConnectionStatus>.broadcast();
 
   Stream<String> get messages => _messageController.stream;
-  Stream<bool> get connectionStatus => _connectionController.stream;
+  Stream<WsConnectionStatus> get connectionStatus =>
+      _connectionController.stream;
 
   WebSocketService({required this.url, this.channelFactory});
 
   void connect() {
+    if (_channel != null) return;
+    _connectionController.add(WsConnectionStatus.connecting);
     try {
       final connect = channelFactory ??
           ((uri) => WebSocketChannel.connect(uri));
       _channel = connect(Uri.parse(url));
-      _connectionController.add(true);
+      _connectionController.add(WsConnectionStatus.connected);
       _channel!.stream.listen((event) {
         _messageController.add(event);
       }, onError: (_) {
-        _connectionController.add(false);
+        _connectionController.add(WsConnectionStatus.disconnected);
       }, onDone: () {
-        _connectionController.add(false);
+        _connectionController.add(WsConnectionStatus.disconnected);
+        _channel = null;
       });
     } catch (e) {
-      _connectionController.add(false);
+      _connectionController.add(WsConnectionStatus.disconnected);
+      _channel = null;
     }
   }
 
@@ -37,6 +45,7 @@ class WebSocketService {
 
   void disconnect() {
     _channel?.sink.close();
-    _connectionController.add(false);
+    _channel = null;
+    _connectionController.add(WsConnectionStatus.disconnected);
   }
 }

--- a/lib/features/chat/presentation/pages/chat_screen.dart
+++ b/lib/features/chat/presentation/pages/chat_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../../../../core/network/network_info.dart';
+import '../../../../core/network/websocket_service.dart';
 import '../../../../injection_container.dart';
 import '../bloc/bloc/fetch_all_users_bloc.dart';
 import '../widgets/chat_screen_widgets/chat_header.dart';
@@ -15,17 +15,22 @@ class ChatScreen extends StatefulWidget {
 }
 
 class ChatScreenState extends State<ChatScreen> {
-  bool isConnected = true;
+  late WebSocketService _wsService;
+  WsConnectionStatus wsStatus = WsConnectionStatus.connecting;
   ChatItem? selectedChat;
 
   @override
   void initState() {
     super.initState();
-    locator<NetworkInfo>().isConnected.then((value) {
-      setState(() {
-        isConnected = value;
-      });
+    _wsService = locator<WebSocketService>();
+    _wsService.connectionStatus.listen((status) {
+      if (mounted) {
+        setState(() {
+          wsStatus = status;
+        });
+      }
     });
+    _wsService.connect();
   }
 
   @override
@@ -39,7 +44,7 @@ class ChatScreenState extends State<ChatScreen> {
             Column(
               children: [
                 // App Header
-                AppHeader(isConnected: isConnected),
+                AppHeader(status: wsStatus),
 
                 // Chat List
                 Expanded(

--- a/lib/features/chat/presentation/pages/individual_chat_screen.dart
+++ b/lib/features/chat/presentation/pages/individual_chat_screen.dart
@@ -39,13 +39,12 @@ class _IndividualChatScreenState extends State<IndividualChatScreen> {
     super.initState();
     hiveService = locator<HiveService>();
     _wsService =
-        widget.webSocketService ??
-        WebSocketService(url: 'wss://echo.websocket.events');
+        widget.webSocketService ?? locator<WebSocketService>();
     _wsService.connect();
     _wsService.connectionStatus.listen((status) {
       if (mounted) {
         setState(() {
-          _wsConnected = status;
+          _wsConnected = status == WsConnectionStatus.connected;
         });
       }
     });

--- a/lib/features/chat/presentation/widgets/chat_screen_widgets/chat_header.dart
+++ b/lib/features/chat/presentation/widgets/chat_screen_widgets/chat_header.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'connection_status.dart';
+import '../../../../core/network/websocket_service.dart';
 
 class AppHeader extends StatelessWidget {
-  final bool isConnected;
+  final WsConnectionStatus status;
 
-  const AppHeader({super.key, required this.isConnected});
+  const AppHeader({super.key, required this.status});
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +26,7 @@ class AppHeader extends StatelessWidget {
             ),
           ),
           SizedBox(height: 16),
-          ConnectionStatus(isConnected: isConnected),
+          ConnectionStatus(status: status),
         ],
       ),
     );

--- a/lib/features/chat/presentation/widgets/chat_screen_widgets/connection_status.dart
+++ b/lib/features/chat/presentation/widgets/chat_screen_widgets/connection_status.dart
@@ -1,24 +1,32 @@
 import 'package:flutter/material.dart';
+import '../../../../core/network/websocket_service.dart';
 
 class ConnectionStatus extends StatelessWidget {
-  final bool isConnected;
+  final WsConnectionStatus status;
 
-  const ConnectionStatus({super.key, required this.isConnected});
+  const ConnectionStatus({super.key, required this.status});
 
   @override
   Widget build(BuildContext context) {
+    if (status == WsConnectionStatus.connecting) {
+      return const Text(
+        'Connecting...',
+        style: TextStyle(fontSize: 14),
+      );
+    }
+
+    final isConnected = status == WsConnectionStatus.connected;
+
     return Row(
       children: [
-        
-      
         Text(
-          isConnected ? 'Connected to server' : 'Disconnected from server',
+          isConnected ? 'Active' : 'Disconnected from server',
           style: TextStyle(
             fontSize: 14,
             color: Colors.grey.shade600,
           ),
         ),
-          SizedBox(width: 8),
+        const SizedBox(width: 8),
         Container(
           width: 12,
           height: 12,

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -14,6 +14,7 @@ import 'features/chat/data/repositories/user_repository_impl.dart';
 import 'features/chat/domain/repositories/user_repository.dart';
 import 'features/chat/domain/usecases/get_all_users_usecase.dart';
 import 'features/chat/presentation/bloc/bloc/fetch_all_users_bloc.dart';
+import 'core/network/websocket_service.dart';
 
 final locator = GetIt.instance;
 
@@ -40,6 +41,9 @@ Future<void> setupDependency() async {
   );
   locator.registerLazySingleton<ChatRemoteDataSource>(
     () => ChatRemoteDataSourceImpl(client: locator()),
+  );
+  locator.registerLazySingleton<WebSocketService>(
+    () => WebSocketService(url: 'wss://echo.websocket.events'),
   );
   locator.registerLazySingleton<UserRepository>(
     () => UsersRepostoryImpl(

--- a/test/chat_screen_test.dart
+++ b/test/chat_screen_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
-import 'package:chat_app_1/core/network/network_info.dart';
+import 'package:chat_app_1/core/network/websocket_service.dart';
 import 'package:chat_app_1/injection_container.dart';
 
 class MockUserBloc extends MockBloc<UserEvent, UserState> implements UserBloc {}
@@ -16,14 +16,23 @@ class FakeUserEvent extends Fake implements UserEvent {}
 
 class FakeUserState extends Fake implements UserState {}
 
-class FakeNetworkInfo extends Fake implements NetworkInfo {
+class FakeWebSocketService extends WebSocketService {
+  FakeWebSocketService() : super(url: 'ws://test');
+  final StreamController<WsConnectionStatus> _controller =
+      StreamController<WsConnectionStatus>.broadcast();
+
   @override
-  Future<bool> get isConnected async => true;
+  Stream<WsConnectionStatus> get connectionStatus => _controller.stream;
+
+  @override
+  void connect() {
+    _controller.add(WsConnectionStatus.connected);
+  }
 }
 
 void main() {
   setUpAll(() {
-    locator.registerSingleton<NetworkInfo>(FakeNetworkInfo());
+    locator.registerSingleton<WebSocketService>(FakeWebSocketService());
     registerFallbackValue(FakeUserEvent());
     registerFallbackValue(FakeUserState());
   });

--- a/test/individual_chat_screen_test.dart
+++ b/test/individual_chat_screen_test.dart
@@ -40,17 +40,18 @@ class FakeWebSocketService extends WebSocketService {
   FakeWebSocketService() : super(url: 'ws://test');
   final List<String> sent = [];
   final StreamController<String> _controller = StreamController.broadcast();
-  final StreamController<bool> _status = StreamController<bool>.broadcast();
+  final StreamController<WsConnectionStatus> _status =
+      StreamController<WsConnectionStatus>.broadcast();
 
   @override
   Stream<String> get messages => _controller.stream;
 
   @override
-  Stream<bool> get connectionStatus => _status.stream;
+  Stream<WsConnectionStatus> get connectionStatus => _status.stream;
 
   @override
   void connect() {
-    _status.add(true);
+    _status.add(WsConnectionStatus.connected);
   }
 
   @override
@@ -62,7 +63,7 @@ class FakeWebSocketService extends WebSocketService {
 
   @override
   void disconnect() {
-    _status.add(false);
+    _status.add(WsConnectionStatus.disconnected);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `WsConnectionStatus` enum and expose connection state stream
- register global `WebSocketService`
- display websocket state in `AppHeader`
- update chat and individual chat screens to use the new service
- adapt tests for the websocket status changes

## Testing
- `flutter format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d28bfd508326ae26b3c6dbe20b49