### PR TITLE
Move connection status indicator to ChatAppBar

### DIFF
--- a/lib/features/chat/presentation/pages/chat_screen.dart
+++ b/lib/features/chat/presentation/pages/chat_screen.dart
@@ -16,20 +16,12 @@ class ChatScreen extends StatefulWidget {
 
 class ChatScreenState extends State<ChatScreen> {
   late WebSocketService _wsService;
-  WsConnectionStatus wsStatus = WsConnectionStatus.connecting;
   ChatItem? selectedChat;
 
   @override
   void initState() {
     super.initState();
     _wsService = locator<WebSocketService>();
-    _wsService.connectionStatus.listen((status) {
-      if (mounted) {
-        setState(() {
-          wsStatus = status;
-        });
-      }
-    });
     _wsService.connect();
   }
 
@@ -44,7 +36,7 @@ class ChatScreenState extends State<ChatScreen> {
             Column(
               children: [
                 // App Header
-                AppHeader(status: wsStatus),
+                const AppHeader(),
 
                 // Chat List
                 Expanded(

--- a/lib/features/chat/presentation/pages/individual_chat_screen.dart
+++ b/lib/features/chat/presentation/pages/individual_chat_screen.dart
@@ -35,7 +35,7 @@ class _IndividualChatScreenState extends State<IndividualChatScreen> {
   late WebSocketService _wsService;
   late StreamSubscription<WsConnectionStatus> _connectionSubscription;
   late StreamSubscription<String> _messagesSubscription;
-  bool _wsConnected = false;
+  WsConnectionStatus _wsStatus = WsConnectionStatus.connecting;
   bool _showTyping = false;
 
   @override
@@ -47,7 +47,7 @@ class _IndividualChatScreenState extends State<IndividualChatScreen> {
     _connectionSubscription = _wsService.connectionStatus.listen((status) {
       if (!mounted) return;
       setState(() {
-        _wsConnected = status == WsConnectionStatus.connected;
+        _wsStatus = status;
       });
     });
     _messagesSubscription = _wsService.messages.listen((message) {
@@ -176,7 +176,7 @@ class _IndividualChatScreenState extends State<IndividualChatScreen> {
       appBar: ChatAppBar(
         contactName: widget.contactName,
         contactAvatar: widget.contactAvatar,
-        isConnected: _wsConnected,
+        status: _wsStatus,
       ),
       body: SafeArea(
         child: Column(

--- a/lib/features/chat/presentation/widgets/chat_screen_widgets/chat_header.dart
+++ b/lib/features/chat/presentation/widgets/chat_screen_widgets/chat_header.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
-import '../../../../../core/network/websocket_service.dart';
-import 'connection_status.dart';
+
 
 class AppHeader extends StatelessWidget {
-  final WsConnectionStatus status;
-
-  const AppHeader({super.key, required this.status});
+  const AppHeader({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -14,20 +11,13 @@ class AppHeader extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border(bottom: BorderSide(color: Colors.grey.shade100)),
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(
-            "Chatting",
-            style: TextStyle(
-              fontSize: 28,
-              fontWeight: FontWeight.bold,
-              color: Colors.black,
-            ),
-          ),
-          SizedBox(height: 16),
-          ConnectionStatus(status: status),
-        ],
+      child: Text(
+        "Chatting",
+        style: TextStyle(
+          fontSize: 28,
+          fontWeight: FontWeight.bold,
+          color: Colors.black,
+        ),
       ),
     );
   }

--- a/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_app_bar.dart
+++ b/lib/features/chat/presentation/widgets/individual_chat_screen_widget/chat_app_bar.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
 
 import '../chat_screen_widgets/chat_avatar.dart';
+import '../chat_screen_widgets/connection_status.dart';
+import '../../../../../core/network/websocket_service.dart';
 
 class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String contactName;
   final String contactAvatar;
-  final bool isConnected;
+  final WsConnectionStatus status;
 
   const ChatAppBar({
     super.key,
     required this.contactName,
     required this.contactAvatar,
-    required this.isConnected,
+    required this.status,
   });
 
   @override
@@ -45,11 +47,7 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         Padding(
           padding: EdgeInsets.only(right: 12),
-          child: Icon(
-            Icons.circle,
-            color: isConnected ? Colors.green : Colors.red,
-            size: 12,
-          ),
+          child: ConnectionStatus(status: status),
         )
       ],
     );

--- a/test/individual_chat_screen_test.dart
+++ b/test/individual_chat_screen_test.dart
@@ -89,8 +89,7 @@ void main() {
     );
     await tester.pump();
 
-    final icon = tester.widget<Icon>(find.byIcon(Icons.circle));
-    expect(icon.color, Colors.green);
+    expect(find.text('Active'), findsOneWidget);
 
     await tester.enterText(find.byType(TextField), 'hi');
     await tester.tap(find.byIcon(Icons.send));


### PR DESCRIPTION
## Summary
- simplify `AppHeader` by removing connection status
- track WebSocket status in `IndividualChatScreen`
- show the connection status in `ChatAppBar`
- update tests for the new app bar indicator

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6885d869154c8326a082ac8f5822901d