### PR TITLE
Add getMessagesForChat implementation

### DIFF
--- a/lib/features/chat/data/datasources/chat_local_data_source.dart
+++ b/lib/features/chat/data/datasources/chat_local_data_source.dart
@@ -10,6 +10,9 @@ abstract class ChatLocalDataSource {
   /// Throws [CacheException] if no cached messages exist.
   Future<List<ChatMessage>> getCachedMessages();
 
+  /// Gets all messages exchanged between [userA] and [userB].
+  Future<List<ChatMessage>> getMessagesForChat(String userA, String userB);
+
   /// Caches a single chat message.
   Future<void> cacheMessage(ChatMessage message);
 
@@ -45,6 +48,16 @@ class ChatLocalDataSourceImpl implements ChatLocalDataSource {
     } else {
       throw CacheException();
     }
+  }
+
+  @override
+  Future<List<ChatMessage>> getMessagesForChat(
+      String userA, String userB) async {
+    final filtered = chatBox.values
+        .where((m) => (m.senderId == userA && m.receiverId == userB) ||
+            (m.senderId == userB && m.receiverId == userA))
+        .toList();
+    return filtered;
   }
 
   @override

--- a/test/fake_chat_local_data_source.dart
+++ b/test/fake_chat_local_data_source.dart
@@ -13,6 +13,14 @@ class FakeChatLocalDataSource implements ChatLocalDataSource {
   Future<List<ChatMessage>> getCachedMessages() async => storedMessages;
 
   @override
+  Future<List<ChatMessage>> getMessagesForChat(String userA, String userB) async {
+    return storedMessages
+        .where((m) => (m.senderId == userA && m.receiverId == userB) ||
+            (m.senderId == userB && m.receiverId == userA))
+        .toList();
+  }
+
+  @override
   Future<void> cacheUserProfile(User profile) async {}
 
   @override


### PR DESCRIPTION
## Summary
- add `getMessagesForChat` to `ChatLocalDataSource`
- implement message filter logic
- update fake data source for tests

## Testing
- `flutter pub get` *(fails: current Dart SDK version is 3.3.3, but pubspec requires >=3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_6885e7c91a348326be302ea156feda57