### PR TITLE
Fix connection status never showing connected

### DIFF
--- a/lib/features/chat/presentation/bloc/chat/connection_cubit.dart
+++ b/lib/features/chat/presentation/bloc/chat/connection_cubit.dart
@@ -7,8 +7,8 @@ class ConnectionCubit extends Cubit<WsConnectionStatus> {
   StreamSubscription<WsConnectionStatus>? _sub;
 
   ConnectionCubit(this.service) : super(WsConnectionStatus.connecting) {
-    service.connect();
     _sub = service.connectionStatus.listen(emit);
+    service.connect();
   }
 
   @override


### PR DESCRIPTION
## Summary
- keep the last websocket status so new listeners see the current state
- listen to connection status before calling `connect()`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68860606f0608326afc3147d607a2c6c